### PR TITLE
Added "Require Active Citizen" Toggle for 911 Calls

### DIFF
--- a/mdt_config.lua.sample
+++ b/mdt_config.lua.sample
@@ -31,6 +31,7 @@ cfg.call_number = "999" -- The number that is dialed when a citizen places a cal
 cfg.call_ring_filename = "ringing_uk.ogg" -- Sound file used for ringing tone
 cfg.call_busy_filename = "busy_uk.ogg" -- Sound file used for busy tone
 cfg.self_dispatch = false -- Enable self dispatch in the MDT
+cfg.call_require_citizen = true -- Requires an Active Citizen to call.
 
 -- ##################################
 

--- a/server/modules/comms/client_receiver.lua
+++ b/server/modules/comms/client_receiver.lua
@@ -131,7 +131,7 @@ function client_receiver.client_event_handlers()
         "open_call",
         function()
             print_debug("RECEIVED REQUEST FROM CLIENT TO OPEN CALL FOR USER " .. source)
-            if (hasCitizen(source)) then
+            if ((not conf.val('call_require_citizen')) or hasCitizen(source)) then
                 client_sender.pass_data(nil, "open_call", source)
             else
                 client_sender.pass_data("Only a citizen can do this", "send_chat", source)
@@ -179,7 +179,7 @@ function client_receiver.client_event_handlers()
         "citizen_call",
         function(data)
             print_debug("RECEIVED REQUEST FROM CLIENT TO SEND CITIZEN CALL")
-            if (hasCitizen(source)) then
+            if ((not conf.val('call_require_citizen')) or hasCitizen(source)) then
                 citizens.send_call(data, client_sender.pass_data, source)
             else
                 client_sender.pass_data("Only a citizen can do this", "send_chat", source)


### PR DESCRIPTION
Added a configuration option to allow users to specify whether or not they want to require users to have an active citizen in order to call 911.  This has been tested and works.  