### PR TITLE
Revert "Added "Require Active Citizen" Toggle for 911 Calls"

### DIFF
--- a/mdt_config.lua.sample
+++ b/mdt_config.lua.sample
@@ -31,7 +31,6 @@ cfg.call_number = "999" -- The number that is dialed when a citizen places a cal
 cfg.call_ring_filename = "ringing_uk.ogg" -- Sound file used for ringing tone
 cfg.call_busy_filename = "busy_uk.ogg" -- Sound file used for busy tone
 cfg.self_dispatch = false -- Enable self dispatch in the MDT
-cfg.call_require_citizen = true -- Requires an Active Citizen to call.
 
 -- ##################################
 

--- a/server/modules/comms/client_receiver.lua
+++ b/server/modules/comms/client_receiver.lua
@@ -131,7 +131,7 @@ function client_receiver.client_event_handlers()
         "open_call",
         function()
             print_debug("RECEIVED REQUEST FROM CLIENT TO OPEN CALL FOR USER " .. source)
-            if ((not conf.val('call_require_citizen')) or hasCitizen(source)) then
+            if (hasCitizen(source)) then
                 client_sender.pass_data(nil, "open_call", source)
             else
                 client_sender.pass_data("Only a citizen can do this", "send_chat", source)
@@ -179,7 +179,7 @@ function client_receiver.client_event_handlers()
         "citizen_call",
         function(data)
             print_debug("RECEIVED REQUEST FROM CLIENT TO SEND CITIZEN CALL")
-            if ((not conf.val('call_require_citizen')) or hasCitizen(source)) then
+            if (hasCitizen(source)) then
                 citizens.send_call(data, client_sender.pass_data, source)
             else
                 client_sender.pass_data("Only a citizen can do this", "send_chat", source)


### PR DESCRIPTION
Reverts CADvanced/cadvanced_mdt#3

I need to pay more attention, I'd not noticed that this PR isn't on the source repo (https://github.com/Chuckatron/cadvanced_mdt). This repo is just for releases (it just contains the bundle, rather than the full source).

I'm really sorry, would you be able to create the PR on the source repo? I realise it's a nuisance, I'm really sorry for not noticing this sooner!